### PR TITLE
use tempfile.gettempdir() to find temporary folder

### DIFF
--- a/ptmv/snd.py
+++ b/ptmv/snd.py
@@ -1,12 +1,14 @@
 import os
 import subprocess
+import tempfile
 import time
 import wave
 import simpleaudio
 
 def extract(file):
-	if not os.path.exists("/tmp/ptmv"): os.makedirs("/tmp/ptmv")
-	snd_file = "/tmp/ptmv/" + str(int(time.time())) + ".wav"
+	ptmv_tempdir = os.path.join(tempfile.gettempdir(), "ptmv")
+	if not os.path.exists(ptmv_tempdir): os.makedirs(ptmv_tempdir)
+	snd_file = ptmv_tempdir + str(int(time.time())) + ".wav"
 	command = "ffmpeg -i " + file + " -b:a 48k -ac 1 " + snd_file
 	subprocess.run(command.split(), stdout = subprocess.DEVNULL, stderr = subprocess.DEVNULL)
 	return snd_file

--- a/ptmv/yt.py
+++ b/ptmv/yt.py
@@ -1,11 +1,13 @@
 from __future__ import unicode_literals
 import yt_dlp as ytdl
 import os
+import tempfile
 import time
 
 def download(url):
-	if not os.path.exists("/tmp/ptmv"): os.makedirs("/tmp/ptmv")
-	file = "/tmp/ptmv/" + str(int(time.time()))
+	ptmv_tempdir = os.path.join(tempfile.gettempdir(), "ptmv")
+	if not os.path.exists(ptmv_tempdir): os.makedirs(ptmv_tempdir)
+	file = ptmv_tempdir + str(int(time.time()))
 	
 	ydl_opts = {
 		"format": "worst[ext=mp4]",


### PR DESCRIPTION
Cool terminal media viewer :)

This commit just has some small changes regarding the `/tmp/ptmv` directory. It's probably better to use `tempfile.gettempdir()` to find the relevant temporary folder, since it has cross-platform functionality. On Windows, the code would still work, but it would create a `C:\tmp\ptmv` folder, which is probably not the desired behavior since `C:\tmp` isn't a standard folder.