### PR TITLE
Replace quadratic-time string concatenation with linear-time joins.

### DIFF
--- a/ptmv/console.py
+++ b/ptmv/console.py
@@ -34,18 +34,19 @@ def cleanup():
 def draw_image(image): draw_frame(None, image)
 
 def draw_frame(prev, current):
-	instructions = ""
+	instructions = []
+	add = instructions.append
 
 	nextPos = (-1, -1)
 	for i in range(0, current.shape[0] - 1, 2):
 		for j in range(0, current.shape[1] - 1):
 			if prev is None or not (pixel_equals(prev, current, i, j) and pixel_equals(prev, current, i + 1, j)):
-				instructions += _fg_color(current[i, j, 2], current[i, j, 1], current[i, j, 0])
-				instructions += _bg_color(current[i + 1, j, 2], current[i + 1, j, 1], current[i + 1, j, 0])
-				if not (i, j) == nextPos: instructions += _move_cursor(j + 1, i / 2 + 1)
-				instructions += "▄"
+				add(_fg_color(current[i, j, 2], current[i, j, 1], current[i, j, 0]))
+				add(_bg_color(current[i + 1, j, 2], current[i + 1, j, 1], current[i + 1, j, 0]))
+				if not (i, j) == nextPos: add(_move_cursor(j + 1, i / 2 + 1))
+				add("▄")
 				nextPos = (i, j + 1)
 
-	sys.stdout.write(instructions)
+	sys.stdout.write("".join(instructions))
 
 def pixel_equals(a, b, i, j): return a[i, j, 0] == b[i, j, 0] and a[i, j, 1] == b[i, j, 1] and a[i, j, 2] == b[i, j, 2]


### PR DESCRIPTION
Here's a micro-benchmark comparing string concatenation with list appending:

```
$ python3 -m timeit \
  -s 'def test():' \
  -s '  x = ""' \
  -s '  for _ in range(99999): x += "a"' \
  -s '  return x' \
  'test()'
10 loops, best of 5: 23.7 msec per loop
```

```
$ python3 -m timeit \
  -s 'def test():' \
  -s '  x = []' \
  -s '  add = x.append' \
  -s '  for _ in range(99999): add("a")' \
  -s '  return "".join(x)' \
  'test()'
20 loops, best of 5: 14.8 msec per loop
```

Seems like this would particularly help when rendering videos.